### PR TITLE
Use for loop instead of str.replace

### DIFF
--- a/src/hwcrypto.js
+++ b/src/hwcrypto.js
@@ -20,11 +20,11 @@ var hwcrypto = (function hwcrypto() {
 
     function _hex2array(str) {
         if(typeof str == 'string') {
-            var ret = new Uint8Array(Math.floor(str.length / 2));
-            var i = 0;
-            str.replace(/(..)/g, function(str) {
-                ret[i++] = parseInt(str, 16);
-            });
+            var len = Math.floor(str.length / 2);
+            var ret = new Uint8Array(len);
+            for (var i = 0; i < len; i++) {
+                ret[i] = parseInt(str.substr(i * 2, 2), 16);
+            }
             return ret;
         }
     }


### PR DESCRIPTION
Currently `_hex2array` uses `String.replace(/(..)/)` to build an array out of a hex string. Even though convenient this is way much slower than a normal `for` loop with `String.substr()`. In my tests, the current solution is more than 80% slower than the proposed one, see the jsperf test case [here](http://jsperf.com/str-replace-vs-for).